### PR TITLE
add to_array from_array; move docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,41 @@ MoonBit does not have `num_traits::Float` so this library is only using `Float`(
 moon add tiye/quaternion
 ```
 
-Find docs on Mooncaches.
+Find docs on [Mooncakes](https://mooncakes.io/docs/#/tiye/quaternion/lib/members).
+
+```moonbit
+let a = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 };
+a.w;
+
+// quick creates
+let b1 = q(1.0, 2.0, 3.0, 4.0);
+//
+// quick creates with integers
+let b2 = qi(1, 2, 3, 4);
+
+b1 + b2;
+b1 - b2;
+b1 * b2;
+b1 / b2;
+b1.conjugate();
+b1.scale(1.5);
+b1.square_length();
+b1.length();
+b1.inverse();
+```
+
+There are also mutable APIs:
+
+```moonbit
+let mut c = Quaternion::id();
+let b = qi(1, 2, 3, 4);
+
+c += b;
+c -= b;
+c *= b;
+// no division
+
+c.inverse_mut();
+c.conjugate_mut();
+c.scale_mut(1.5);
+```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ b1.scale(1.5);
 b1.square_length();
 b1.length();
 b1.inverse();
+
+a.to_array();
+a.to_xyzw()
+
+Quaternion::from_array([1.0, 2.0, 3.0, 4.0]);
+Quaternion::from_xyzw_array(1.0, 2.0, 3.0, 4.0);
 ```
 
 There are also mutable APIs:

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "tiye/quaternion",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "README.md",
   "repository": "https://github.com/WebGPU-Art/quaternion",
   "license": "Apache-2.0",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "tiye/quaternion",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "readme": "README.md",
   "repository": "https://github.com/WebGPU-Art/quaternion",
   "license": "Apache-2.0",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "tiye/quaternion",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "readme": "README.md",
   "repository": "https://github.com/WebGPU-Art/quaternion",
   "license": "Apache-2.0",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "tiye/quaternion",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "readme": "README.md",
   "repository": "https://github.com/WebGPU-Art/quaternion",
   "license": "Apache-2.0",

--- a/src/lib/euler.mbt
+++ b/src/lib/euler.mbt
@@ -1,0 +1,23 @@
+///| Construct a quaternion representing the given euler angle rotations (in radians)
+pub fn Quaternion::from_euler_angles(
+  x : Float,
+  y : Float,
+  z : Float
+) -> Quaternion {
+  let two : Float = 2.0
+  let half_x = x / two
+  let half_y = y / two
+  let half_z = z / two
+  let cos_x_2 = @math.cos(half_x.to_double()).to_float()
+  let cos_y_2 = @math.cos(half_y.to_double()).to_float()
+  let cos_z_2 = @math.cos(half_z.to_double()).to_float()
+  let sin_x_2 = @math.sin(half_x.to_double()).to_float()
+  let sin_y_2 = @math.sin(half_y.to_double()).to_float()
+  let sin_z_2 = @math.sin(half_z.to_double()).to_float()
+  Quaternion::{
+    w: cos_x_2 * cos_y_2 * cos_z_2 + sin_x_2 * sin_y_2 * sin_z_2,
+    x: sin_x_2 * cos_y_2 * cos_z_2 + cos_x_2 * sin_y_2 * sin_z_2,
+    y: cos_x_2 * sin_y_2 * cos_z_2 + sin_x_2 * cos_y_2 * sin_z_2,
+    z: cos_x_2 * cos_y_2 * sin_z_2 + sin_x_2 * sin_y_2 * cos_z_2,
+  }
+}

--- a/src/lib/euler.mbt
+++ b/src/lib/euler.mbt
@@ -1,4 +1,5 @@
 ///| Construct a quaternion representing the given euler angle rotations (in radians)
+/// Notice: this function is not well tested yet
 pub fn Quaternion::from_euler_angles(
   x : Float,
   y : Float,

--- a/src/lib/quaternion.mbt
+++ b/src/lib/quaternion.mbt
@@ -199,6 +199,11 @@ pub fn Quaternion::to_array(self : Quaternion) -> Array[Float] {
   [self.w, self.x, self.y, self.z]
 }
 
+///| convert to xyzw, useful for Graphics
+pub fn Quaternion::to_xyzw(self : Quaternion) -> Array[Float] {
+  [self.x, self.y, self.z, self.w]
+}
+
 ///|
 pub(all) type! QuatError String
 

--- a/src/lib/quaternion.mbt
+++ b/src/lib/quaternion.mbt
@@ -1,44 +1,3 @@
-/// Using Float in this module, MoonBit does not support generics in Trait yet.
-///
-//! a simpler quaternion math library with traits.
-//!
-//! ```moonbit
-//! let a = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 };
-//! a.w;
-//!
-//! // quick creates
-//! let b1 = q(1.0, 2.0, 3.0, 4.0);
-//!
-//! // quick creates with integers
-//! let b2 = qi(1, 2, 3, 4);
-//!
-//! b1 + b2;
-//! b1 - b2;
-//! b1 * b2;
-//! b1 / b2;
-//! b1.conjugate();
-//! b1.scale(1.5);
-//! b1.square_length();
-//! b1.length();
-//! b1.inverse();
-//!```
-//!
-//! There are also mutable APIs:
-//!
-//! ```moonbit
-//! let mut c = Quaternion::id();
-//! let b = qi(1, 2, 3, 4);
-//!
-//! c += b;
-//! c -= b;
-//! c *= b;
-//! // no division
-//! c.inverse_mut();
-//! c.conjugate_mut();
-//! c.scale_mut(1.5);
-//! ```
-//!
-
 ///| Quaternion {w, x, y, z}
 pub(all) struct Quaternion {
   mut w : Float
@@ -233,6 +192,22 @@ pub fn Quaternion::op_sub_assign(self : Quaternion, other : Quaternion) -> Unit 
 ///| negate number
 pub fn Quaternion::op_neg(self : Quaternion) -> Quaternion {
   Quaternion::{ w: -self.w, x: -self.x, y: -self.y, z: -self.z }
+}
+
+///|
+pub fn Quaternion::to_array(self : Quaternion) -> Array[Float] {
+  [self.w, self.x, self.y, self.z]
+}
+
+///|
+pub(all) type! QuatError String
+
+///|
+pub fn Quaternion::from_array(arr : Array[Float]) -> Quaternion!QuatError {
+  if arr.length() != 4 {
+    raise QuatError("Array must have 4 elements")
+  }
+  Quaternion::{ w: arr[0], x: arr[1], y: arr[2], z: arr[3] }
 }
 
 ///| Construct a quaternion representing the given euler angle rotations (in radians)

--- a/src/lib/quaternion.mbt
+++ b/src/lib/quaternion.mbt
@@ -215,6 +215,14 @@ pub fn Quaternion::from_array(arr : Array[Float]) -> Quaternion!QuatError {
   Quaternion::{ w: arr[0], x: arr[1], y: arr[2], z: arr[3] }
 }
 
+///| from_xyzw_array
+pub fn Quaternion::from_xyzw_array(arr : Array[Float]) -> Quaternion!QuatError {
+  if arr.length() != 4 {
+    raise QuatError("Array must have 4 elements")
+  }
+  Quaternion::{ w: arr[3], x: arr[0], y: arr[1], z: arr[2] }
+}
+
 ///| Construct a quaternion representing the given euler angle rotations (in radians)
 pub fn Quaternion::from_euler_angles(
   x : Float,

--- a/src/lib/quaternion.mbt
+++ b/src/lib/quaternion.mbt
@@ -114,6 +114,15 @@ pub fn Quaternion::op_eq(self : Quaternion, other : Quaternion) -> Bool {
   (self - other).square_length() < 1.0.to_float() / max_value
 }
 
+///|
+pub fn Quaternion::roughly_eq(
+  self : Quaternion,
+  other : Quaternion,
+  epsilon? : Float
+) -> Bool {
+  (self - other).square_length() < epsilon.or(0.00000000001)
+}
+
 ///| Adds two quaternions, returns a new one.
 pub fn Quaternion::op_add(self : Quaternion, other : Quaternion) -> Quaternion {
   Quaternion::{
@@ -223,26 +232,24 @@ pub fn Quaternion::from_xyzw_array(arr : Array[Float]) -> Quaternion!QuatError {
   Quaternion::{ w: arr[3], x: arr[0], y: arr[1], z: arr[2] }
 }
 
-///| Construct a quaternion representing the given euler angle rotations (in radians)
-pub fn Quaternion::from_euler_angles(
-  x : Float,
-  y : Float,
-  z : Float
-) -> Quaternion {
-  let two : Float = 2.0
-  let half_x = x / two
-  let half_y = y / two
-  let half_z = z / two
-  let cos_x_2 = @math.cos(half_x.to_double()).to_float()
-  let cos_y_2 = @math.cos(half_y.to_double()).to_float()
-  let cos_z_2 = @math.cos(half_z.to_double()).to_float()
-  let sin_x_2 = @math.sin(half_x.to_double()).to_float()
-  let sin_y_2 = @math.sin(half_y.to_double()).to_float()
-  let sin_z_2 = @math.sin(half_z.to_double()).to_float()
-  Quaternion::{
-    w: cos_x_2 * cos_y_2 * cos_z_2 + sin_x_2 * sin_y_2 * sin_z_2,
-    x: sin_x_2 * cos_y_2 * cos_z_2 + cos_x_2 * sin_y_2 * sin_z_2,
-    y: cos_x_2 * sin_y_2 * cos_z_2 + sin_x_2 * cos_y_2 * sin_z_2,
-    z: cos_x_2 * cos_y_2 * sin_z_2 + sin_x_2 * sin_y_2 * cos_z_2,
+///|
+pub fn Quaternion::normalize(self : Quaternion) -> Quaternion {
+  let len = self.length()
+  if len == 0.0 {
+    return Quaternion::id()
+  }
+  self.scale(1.0.to_float() / len)
+}
+
+///| normalize mutable
+pub fn Quaternion::normalize_mut(self : Quaternion) -> Unit {
+  let len = self.length()
+  if len == 0.0 {
+    self.w = 1.0
+    self.x = 0.0
+    self.y = 0.0
+    self.z = 0.0
+  } else {
+    self.scale_mut(1.0.to_float() / len)
   }
 }

--- a/src/lib/quaternion.mbt
+++ b/src/lib/quaternion.mbt
@@ -8,6 +8,26 @@ pub(all) struct Quaternion {
 
 // Show
 ///|
+/// Converts a quaternion to its string representation in the format "Quaternion
+/// { w: <w>, x: <x>, y: <y>, z: <z> }".
+///
+/// Parameters:
+///
+/// * `quaternion`: The quaternion to be converted to string.
+///
+/// Returns a string representation of the quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::to_string" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   inspect!(
+///     q.to_string(),
+///     content="Quaternion { w: 1.0, x: 2.0, y: 3.0, z: 4.0 }",
+///   )
+/// }
+/// ```
 pub fn Quaternion::to_string(self : Quaternion) -> String {
   "Quaternion { w: \{self.w}, x: \{self.x}, y: \{self.y}, z: \{self.z} }"
 }
@@ -17,22 +37,110 @@ pub impl Show for Quaternion with output(self, logger) {
   logger.write_string(self.to_string())
 }
 
-///| shortcut of create quaternion
+///|
+/// Creates a new quaternion with the given components. This is a shorter
+/// alternative to using the `Quaternion` constructor directly.
+///
+/// Parameters:
+///
+/// * `w` : The scalar (real) component of the quaternion.
+/// * `x` : The first vector (imaginary) component of the quaternion.
+/// * `y` : The second vector (imaginary) component of the quaternion.
+/// * `z` : The third vector (imaginary) component of the quaternion.
+///
+/// Returns a new `Quaternion` instance with the specified components.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "q" {
+///   let quaternion = q(1.0, 2.0, 3.0, 4.0)
+///   inspect!(
+///     quaternion.to_string(),
+///     content="Quaternion { w: 1.0, x: 2.0, y: 3.0, z: 4.0 }",
+///   )
+/// }
+/// ```
 pub fn q(w : Float, x : Float, y : Float, z : Float) -> Quaternion {
   Quaternion::{ w, x, y, z }
 }
 
-///| shortcut of creating quaternion from integers
+///|
+/// Creates a quaternion from four integer components by converting them to
+/// floating-point numbers. Serves as a convenient shortcut when working with
+/// integer values.
+///
+/// Parameters:
+///
+/// * `w` : The real (scalar) component of the quaternion.
+/// * `x` : The first imaginary component (i coefficient).
+/// * `y` : The second imaginary component (j coefficient).
+/// * `z` : The third imaginary component (k coefficient).
+///
+/// Returns a new quaternion with the integer components converted to
+/// floating-point numbers.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "qi" {
+///   let quaternion = qi(1, 2, 3, 4)
+///   inspect!(quaternion, content="Quaternion { w: 1.0, x: 2.0, y: 3.0, z: 4.0 }")
+/// }
+/// ```
 pub fn qi(w : Int, x : Int, y : Int, z : Int) -> Quaternion {
   q(w.to_float(), x.to_float(), y.to_float(), z.to_float())
 }
 
-///| returns an identity quaternion
+///|
+/// Returns an identity quaternion, which is a quaternion with w=1 and x=y=z=0.
+/// An identity quaternion represents no rotation in 3D space and acts as a
+/// multiplicative identity for quaternion multiplication.
+///
+/// Returns a quaternion representing the identity rotation.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::id" {
+///   let q = Quaternion::id()
+///   inspect!(q, content="Quaternion { w: 1.0, x: 0.0, y: 0.0, z: 0.0 }")
+///
+///   // demonstrate identity property
+///   let p = Quaternion::{ w: 2.0, x: 3.0, y: 4.0, z: 5.0 }
+///   inspect!(p * q, content=p.to_string())
+/// }
+/// ```
 pub fn Quaternion::id() -> Quaternion {
   Quaternion::{ w: 1.0, x: 0.0, y: 0.0, z: 0.0 }
 }
 
-///| returns a quaternion from xyz
+///|
+/// Creates a new quaternion with optional components. If any component is not
+/// provided, it defaults to 0.0.
+///
+/// Parameters:
+///
+/// * `w` : The scalar (real) component of the quaternion. Defaults to 0.0.
+/// * `x` : The first vector (imaginary) component of the quaternion. Defaults to
+/// 0.0.
+/// * `y` : The second vector (imaginary) component of the quaternion. Defaults
+/// to 0.0.
+/// * `z` : The third vector (imaginary) component of the quaternion. Defaults to
+/// 0.0.
+///
+/// Returns a new `Quaternion` instance with the specified or default components.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::new" {
+///   let q1 = Quaternion::new()
+///   let q2 = Quaternion::new(w=1.0, x=2.0)
+///   inspect!(q1, content="Quaternion { w: 0.0, x: 0.0, y: 0.0, z: 0.0 }")
+///   inspect!(q2, content="Quaternion { w: 1.0, x: 2.0, y: 0.0, z: 0.0 }")
+/// }
+/// ```
 pub fn Quaternion::new(
   w? : Float,
   x? : Float,
@@ -47,12 +155,50 @@ pub fn Quaternion::new(
   }
 }
 
-///| Scales a quaternion (element-wise) by a scalar, returns a new one
+///|
+/// Performs element-wise multiplication of a quaternion with a scalar value,
+/// producing a new quaternion.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be scaled.
+/// * `scalar`: A floating-point value to scale the quaternion with.
+///
+/// Returns a new quaternion where each component (w, x, y, z) is multiplied by
+/// the scalar value.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::scale" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let scaled = q.scale(2.0)
+///   inspect!(scaled, content="Quaternion { w: 2.0, x: 4.0, y: 6.0, z: 8.0 }")
+/// }
+/// ```
 pub fn Quaternion::scale(self : Quaternion, t : Float) -> Quaternion {
   Quaternion::{ w: self.w * t, x: self.x * t, y: self.y * t, z: self.z * t }
 }
 
 ///|
+/// Scales a quaternion by multiplying each component with a scalar value
+/// in-place.
+///
+/// Parameters:
+///
+/// * `self` : The quaternion to be scaled.
+/// * `scalar` : The scaling factor to multiply with each component of the
+/// quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::scale_mut" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   q.scale_mut(2.0)
+///   inspect!(q, content="Quaternion { w: 2.0, x: 4.0, y: 6.0, z: 8.0 }")
+/// }
+/// ```
 pub fn Quaternion::scale_mut(self : Quaternion, t : Float) -> Unit {
   self.w = self.w * t
   self.x = self.x * t
@@ -60,40 +206,170 @@ pub fn Quaternion::scale_mut(self : Quaternion, t : Float) -> Unit {
   self.z = self.z * t
 }
 
-///| return a inverse of a quaternion
+///|
+/// Returns a new quaternion that represents the multiplicative inverse of the
+/// input quaternion. The inverse of a quaternion q satisfies q \* q^(-1) =
+/// q^(-1) \* q = 1 (identity quaternion).
+///
+/// Parameters:
+///
+/// * `quaternion`: The input quaternion to be inverted. Must have non-zero
+/// length.
+///
+/// Returns a new quaternion that is the inverse of the input quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::inverse" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q_inv = q.inverse()
+///   inspect!((q * q_inv).roughly_eq(Quaternion::id()), content="true")
+/// }
+/// ```
 pub fn Quaternion::inverse(self : Quaternion) -> Quaternion {
   self.conjugate().scale(1.0.to_float() / self.square_length())
 }
 
-///| mutable version of inverse
+///|
+/// Mutates the quaternion by computing its inverse (reciprocal).
+///
+/// For a quaternion q = w + xi + yj + zk, its inverse is q⁻¹ =
+/// conjugate(q)/|q|², where |q| is the length of the quaternion.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be inverted in-place.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::inverse_mut" {
+///   let q = Quaternion::{ w: 2.0, x: 0.0, y: 0.0, z: 0.0 }
+///   q.inverse_mut()
+///   inspect!(q, content="Quaternion { w: 0.5, x: 0.0, y: 0.0, z: 0.0 }")
+/// }
+/// ```
 pub fn Quaternion::inverse_mut(self : Quaternion) -> Unit {
   self.scale_mut(1.0.to_float() / self.square_length())
   self.conjugate_mut()
 }
 
-///| returns dot product of two quaternions
+///|
+/// Computes the dot product (scalar product) of two quaternions. The dot product
+/// is calculated as the sum of the products of corresponding components.
+///
+/// Parameters:
+///
+/// * `self` : The first quaternion.
+/// * `other` : The second quaternion.
+///
+/// Returns a float value representing the dot product of the two quaternions.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::dot" {
+///   let q1 = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q2 = Quaternion::{ w: 2.0, x: 3.0, y: 4.0, z: 5.0 }
+///   inspect!(q1.dot(q2), content="40.0")
+/// }
+/// ```
 pub fn Quaternion::dot(self : Quaternion, other : Quaternion) -> Float {
   self.w * other.w + self.x * other.x + self.y * other.y + self.z * other.z
 }
 
-///| Takes the quaternion conjugate, returns a new one.
+///|
+/// Returns a new quaternion that is the conjugate of the given quaternion. A
+/// quaternion conjugate is formed by negating the vector part (x, y, z
+/// components) while keeping the scalar part (w component) unchanged.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be conjugated.
+///
+/// Returns a new quaternion that is the conjugate of the input quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::conjugate" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   inspect!(
+///     q.conjugate(),
+///     content="Quaternion { w: 1.0, x: -2.0, y: -3.0, z: -4.0 }",
+///   )
+/// }
+/// ```
 pub fn Quaternion::conjugate(self : Quaternion) -> Quaternion {
   Quaternion::{ w: self.w, x: -self.x, y: -self.y, z: -self.z }
 }
 
-///| mutable version of conjugate
+///|
+/// Modifies the quaternion in-place by negating its x, y, and z components while
+/// keeping the w component unchanged. The conjugate of a quaternion represents
+/// the same rotation in the opposite direction.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be modified. The quaternion will be changed
+/// in-place.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::conjugate_mut" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   q.conjugate_mut()
+///   inspect!(q, content="Quaternion { w: 1.0, x: -2.0, y: -3.0, z: -4.0 }")
+/// }
+/// ```
 pub fn Quaternion::conjugate_mut(self : Quaternion) -> Unit {
   self.x = -self.x
   self.y = -self.y
   self.z = -self.z
 }
 
-///| Computes the square length of a quaternion.
+///|
+/// Computes the squared length (or squared norm) of a quaternion by summing up
+/// the squares of its components (w² + x² + y² + z²).
+///
+/// Parameters:
+///
+/// * `quaternion`: The quaternion whose squared length is to be computed.
+///
+/// Returns the squared length of the quaternion as a floating-point number.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::square_length" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 2.0, z: 1.0 }
+///   inspect!(q.square_length(), content="10.0")
+/// }
+/// ```
 pub fn Quaternion::square_length(self : Quaternion) -> Float {
   self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z
 }
 
-///| Computes the length of a quaternion.
+///|
+/// Computes the Euclidean length (magnitude) of a quaternion by taking the
+/// square root of the sum of squares of its components.
+///
+/// Parameters:
+///
+/// * `quaternion`: The quaternion whose length is to be computed.
+///
+/// Returns a floating-point number representing the length of the quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::length" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 2.0, z: 1.0 }
+///   inspect!(q.length(), content="3.316624790355399")
+/// }
+/// ```
 pub fn Quaternion::length(self : Quaternion) -> Float {
   self.square_length().sqrt()
 }
@@ -106,15 +382,57 @@ pub impl Default for Quaternion with default() {
 ///|
 pub let max_value : Float = (0x7F7FFFFF).reinterpret_as_float()
 
-///| Returns true if the two quaternions very cloase, compared like:
-/// ```ignore
-/// |a-b|^2 < epsilon
+///|
+/// Determines whether two quaternions are approximately equal by comparing their
+/// squared difference with a small epsilon value. This method is necessary
+/// because direct floating-point comparisons may not work correctly due to
+/// numerical precision issues.
+///
+/// Parameters:
+///
+/// * `self`: The first quaternion to compare.
+/// * `other`: The second quaternion to compare.
+///
+/// Returns `true` if the squared distance between the two quaternions is less
+/// than the epsilon value (which is the reciprocal of the maximum representable
+/// float value), `false` otherwise.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_eq" {
+///   let q1 = Quaternion::{ w: 1.0, x: 0.0, y: 0.0, z: 0.0 }
+///   let q2 = Quaternion::{ w: 1.0, x: 0.0000000001, y: 0.0, z: 0.0 }
+///   inspect!(q1.op_eq(q2), content="true")
+/// }
 /// ```
 pub fn Quaternion::op_eq(self : Quaternion, other : Quaternion) -> Bool {
   (self - other).square_length() < 1.0.to_float() / max_value
 }
 
 ///|
+/// Determines if two quaternions are approximately equal within a specified
+/// epsilon value.
+///
+/// Parameters:
+///
+/// * `self`: The first quaternion to compare.
+/// * `other`: The second quaternion to compare.
+/// * `epsilon`: Optional threshold value for comparison. Defaults to
+/// 0.00000000001 if not provided.
+///
+/// Returns true if the squared difference between the two quaternions is less
+/// than the epsilon value, false otherwise.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::roughly_eq" {
+///   let q1 = Quaternion::{ w: 1.0, x: 0.0, y: 0.0, z: 0.0 }
+///   let q2 = Quaternion::{ w: 0.9999999999, x: 0.0, y: 0.0, z: 0.0 }
+///   inspect!(q1.roughly_eq(q2), content="true")
+/// }
+/// ```
 pub fn Quaternion::roughly_eq(
   self : Quaternion,
   other : Quaternion,
@@ -123,7 +441,26 @@ pub fn Quaternion::roughly_eq(
   (self - other).square_length() < epsilon.or(0.00000000001)
 }
 
-///| Adds two quaternions, returns a new one.
+///|
+/// Adds two quaternions component-wise.
+///
+/// Parameters:
+///
+/// * `self` : The first quaternion.
+/// * `other` : The second quaternion.
+///
+/// Returns a new quaternion where each component is the sum of the corresponding
+/// components of the input quaternions.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_add" {
+///   let q1 = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q2 = Quaternion::{ w: 5.0, x: 6.0, y: 7.0, z: 8.0 }
+///   inspect!(q1 + q2, content="Quaternion { w: 6.0, x: 8.0, y: 10.0, z: 12.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_add(self : Quaternion, other : Quaternion) -> Quaternion {
   Quaternion::{
     w: self.w + other.w,
@@ -133,7 +470,25 @@ pub fn Quaternion::op_add(self : Quaternion, other : Quaternion) -> Quaternion {
   }
 }
 
-///| Adds two quaternions, returns a new one.
+///|
+/// Performs in-place addition of two quaternions by adding their corresponding
+/// components.
+///
+/// Parameters:
+///
+/// * `self` : The quaternion to be modified.
+/// * `other` : The quaternion to be added to `self`.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_add_assign" {
+///   let q1 = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q2 = Quaternion::{ w: 5.0, x: 6.0, y: 7.0, z: 8.0 }
+///   q1.op_add_assign(q2)
+///   inspect!(q1, content="Quaternion { w: 6.0, x: 8.0, y: 10.0, z: 12.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_add_assign(self : Quaternion, other : Quaternion) -> Unit {
   self.w = self.w + other.w
   self.x = self.x + other.x
@@ -141,7 +496,29 @@ pub fn Quaternion::op_add_assign(self : Quaternion, other : Quaternion) -> Unit 
   self.z = self.z + other.z
 }
 
-///| Multiplies two quaternions, returns a new one.
+///|
+/// Performs quaternion multiplication (Hamilton product) of two quaternions. The
+/// operation is non-commutative, meaning `a * b` is not necessarily equal to `b
+/// * a`. This operation can be used to combine rotations represented by
+/// quaternions.
+///
+/// Parameters:
+///
+/// * `self`: The first quaternion operand.
+/// * `other`: The second quaternion operand.
+///
+/// Returns a new quaternion representing the product of the multiplication.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_mul" {
+///   let q1 = Quaternion::{ w: 1.0, x: 0.0, y: 0.0, z: 0.0 }
+///   let q2 = Quaternion::{ w: 0.0, x: 1.0, y: 0.0, z: 0.0 }
+///   let result = q1 * q2
+///   inspect!(result, content="Quaternion { w: 0.0, x: 1.0, y: 0.0, z: 0.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_mul(self : Quaternion, other : Quaternion) -> Quaternion {
   Quaternion::{
     w: self.w * other.w - self.x * other.x - self.y * other.y - self.z * other.z,
@@ -151,7 +528,28 @@ pub fn Quaternion::op_mul(self : Quaternion, other : Quaternion) -> Quaternion {
   }
 }
 
-///| Multiplies two quaternions, returns a new one.
+///|
+/// Performs in-place multiplication of two quaternions using the Hamilton
+/// product rule. The result is stored in the first quaternion.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be modified.
+/// * `other`: The quaternion to multiply with.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_mul_assign" {
+///   let q1 = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q2 = Quaternion::{ w: 2.0, x: -1.0, y: -2.0, z: -3.0 }
+///   q1.op_mul_assign(q2)
+///   inspect!(
+///     q1.to_string(),
+///     content="Quaternion { w: 12.0, x: 1.0, y: 0.0, z: -1.0 }",
+///   )
+/// }
+/// ```
 pub fn Quaternion::op_mul_assign(self : Quaternion, other : Quaternion) -> Unit {
   let w = self.w * other.w -
     self.x * other.x -
@@ -176,11 +574,51 @@ pub fn Quaternion::op_mul_assign(self : Quaternion, other : Quaternion) -> Unit 
 }
 
 ///|
+/// Divides two quaternions by multiplying the first quaternion with the inverse
+/// of the second quaternion.
+///
+/// Parameters:
+///
+/// * `self` : The dividend quaternion.
+/// * `divisor` : The quaternion to divide by.
+///
+/// Returns a new quaternion representing the quotient of the division operation.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_div" {
+///   let a = Quaternion::{ w: 1.0, x: 0.0, y: 0.0, z: 0.0 }
+///   let b = Quaternion::{ w: 2.0, x: 0.0, y: 0.0, z: 0.0 }
+///   let result = a / b
+///   inspect!(result, content="Quaternion { w: 0.5, x: 0.0, y: 0.0, z: 0.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_div(self : Quaternion, b : Quaternion) -> Quaternion {
   self.op_mul(b.inverse())
 }
 
-///| substraction of two quaternions, returning new value
+///|
+/// Performs element-wise subtraction of two quaternions.
+///
+/// Parameters:
+///
+/// * `self`: The minuend quaternion.
+/// * `other`: The subtrahend quaternion.
+///
+/// Returns a new quaternion where each component is the difference of the
+/// corresponding components of the input quaternions.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_sub" {
+///   let q1 = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   let q2 = Quaternion::{ w: 0.5, x: 1.0, y: 1.5, z: 2.0 }
+///   let result = q1 - q2
+///   inspect!(result, content="Quaternion { w: 0.5, x: 1.0, y: 1.5, z: 2.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_sub(self : Quaternion, other : Quaternion) -> Quaternion {
   Quaternion::{
     w: self.w - other.w,
@@ -190,7 +628,25 @@ pub fn Quaternion::op_sub(self : Quaternion, other : Quaternion) -> Quaternion {
   }
 }
 
-///| substraction of two quaternions, returning new value
+///|
+/// Subtracts another quaternion from this quaternion in place, modifying the
+/// original quaternion.
+///
+/// Parameters:
+///
+/// * `self` : The quaternion to be modified.
+/// * `other` : The quaternion to subtract from `self`.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_sub_assign" {
+///   let q1 = Quaternion::{ w: 2.0, x: 3.0, y: 4.0, z: 5.0 }
+///   let q2 = Quaternion::{ w: 1.0, x: 1.0, y: 1.0, z: 1.0 }
+///   q1.op_sub_assign(q2)
+///   inspect!(q1, content="Quaternion { w: 1.0, x: 2.0, y: 3.0, z: 4.0 }")
+/// }
+/// ```
 pub fn Quaternion::op_sub_assign(self : Quaternion, other : Quaternion) -> Unit {
   self.w = self.w - other.w
   self.x = self.x - other.x
@@ -198,17 +654,73 @@ pub fn Quaternion::op_sub_assign(self : Quaternion, other : Quaternion) -> Unit 
   self.z = self.z - other.z
 }
 
-///| negate number
+///|
+/// Returns a new quaternion with all components negated. Equivalent to
+/// multiplying all components by -1.
+///
+/// Parameters:
+///
+/// * `quaternion`: The quaternion to be negated.
+///
+/// Returns a new quaternion where each component (w, x, y, z) is the negation of
+/// the corresponding component in the input quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::op_neg" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   inspect!(
+///     q.op_neg(),
+///     content="Quaternion { w: -1.0, x: -2.0, y: -3.0, z: -4.0 }",
+///   )
+/// }
+/// ```
 pub fn Quaternion::op_neg(self : Quaternion) -> Quaternion {
   Quaternion::{ w: -self.w, x: -self.x, y: -self.y, z: -self.z }
 }
 
 ///|
-pub fn Quaternion::to_array(self : Quaternion) -> Array[Float] {
+/// Converts a quaternion to an array of floats in the order \[w, x, y, z].
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be converted.
+///
+/// Returns an array of four floating-point numbers representing the components
+/// of the quaternion.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::to_array" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   inspect!(q.to_array(), content="[1.0, 2.0, 3.0, 4.0]")
+/// }
+/// ```
+pub fn Quaternion::to_wxyz(self : Quaternion) -> Array[Float] {
   [self.w, self.x, self.y, self.z]
 }
 
-///| convert to xyzw, useful for Graphics
+///|
+/// Converts a quaternion to an array of floats in the order \[x, y, z, w], which
+/// is a common format used in graphics programming.
+///
+/// Parameters:
+///
+/// * `self`: The quaternion to be converted.
+///
+/// Returns an array of four floating-point numbers representing the components
+/// of the quaternion in XYZW order.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Quaternion::to_xyzw" {
+///   let q = Quaternion::{ w: 1.0, x: 2.0, y: 3.0, z: 4.0 }
+///   inspect!(q.to_xyzw(), content="[2.0, 3.0, 4.0, 1.0]")
+/// }
+/// ```
 pub fn Quaternion::to_xyzw(self : Quaternion) -> Array[Float] {
   [self.x, self.y, self.z, self.w]
 }
@@ -217,7 +729,7 @@ pub fn Quaternion::to_xyzw(self : Quaternion) -> Array[Float] {
 pub(all) type! QuatError String
 
 ///|
-pub fn Quaternion::from_array(arr : Array[Float]) -> Quaternion!QuatError {
+pub fn Quaternion::from_wxyz(arr : Array[Float]) -> Quaternion!QuatError {
   if arr.length() != 4 {
     raise QuatError("Array must have 4 elements")
   }
@@ -242,13 +754,10 @@ pub fn Quaternion::normalize(self : Quaternion) -> Quaternion {
 }
 
 ///| normalize mutable
-pub fn Quaternion::normalize_mut(self : Quaternion) -> Unit {
+pub fn Quaternion::normalize_mut(self : Quaternion) -> Unit!QuatError {
   let len = self.length()
   if len == 0.0 {
-    self.w = 1.0
-    self.x = 0.0
-    self.y = 0.0
-    self.z = 0.0
+    raise QuatError("Cannot normalize a zero-length quaternion")
   } else {
     self.scale_mut(1.0.to_float() / len)
   }

--- a/src/lib/quaternion_test.mbt
+++ b/src/lib/quaternion_test.mbt
@@ -234,3 +234,11 @@ test "Quaternion::op_div/basic" {
   )
   inspect!(result * b, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
 }
+
+test "Quaternion::to_array/basic" {
+  let q = @lib.q(1.0, 2.0, 3.0, 4.0)
+  let result = q.to_array()
+  inspect!(result, content="[1, 2, 3, 4]")
+  let result2 = q.to_xyzw()
+  inspect!(result2, content="[2, 3, 4, 1]")
+}

--- a/src/lib/quaternion_test.mbt
+++ b/src/lib/quaternion_test.mbt
@@ -241,4 +241,8 @@ test "Quaternion::to_array/basic" {
   inspect!(result, content="[1, 2, 3, 4]")
   let result2 = q.to_xyzw()
   inspect!(result2, content="[2, 3, 4, 1]")
+  let q2 = @lib.from_xyzw_array?([2.0, 3.0, 4.0, 1.0]).unwrap()
+  inspect!(q2, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
+  let q3 = @lib.from_array?([1.0, 2.0, 3.0, 4.0]).unwrap()
+  inspect!(q3, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
 }

--- a/src/lib/quaternion_test.mbt
+++ b/src/lib/quaternion_test.mbt
@@ -237,14 +237,21 @@ test "Quaternion::op_div/basic" {
 
 test "Quaternion::to_array/basic" {
   let q = @lib.q(1.0, 2.0, 3.0, 4.0)
-  let result = q.to_array()
+  let result = q.to_wxyz()
   inspect!(result, content="[1, 2, 3, 4]")
   let result2 = q.to_xyzw()
   inspect!(result2, content="[2, 3, 4, 1]")
   let q2 = @lib.from_xyzw_array?([2.0, 3.0, 4.0, 1.0]).unwrap()
   inspect!(q2, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
-  let q3 = @lib.from_array?([1.0, 2.0, 3.0, 4.0]).unwrap()
+  let q3 = @lib.from_wxyz?([1.0, 2.0, 3.0, 4.0]).unwrap()
   inspect!(q3, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
+}
+
+test "Quaternion::to_array/fail" {
+  let result = @lib.from_wxyz?([1.0, 2.0, 3.0])
+  inspect!(result.is_err(), content="true")
+  let result2 = @lib.from_xyzw_array?([1.0, 2.0, 3.0])
+  inspect!(result2.is_err(), content="true")
 }
 
 test "Quaternion::normalize/basic" {
@@ -262,6 +269,9 @@ test "Quaternion::normalize/basic" {
   )
   inspect!(result.length(), content="1")
   let q2 = @lib.q(1.0, 2.0, 3.0, 4.0)
-  q2.normalize_mut()
+  q2.normalize_mut?().unwrap()
   inspect!(q2.length(), content="1")
+  let q3 = @lib.q(0.0, 0.0, 0.0, 0.0)
+  let ret = q3.normalize_mut?()
+  inspect!(ret.is_err(), content="true")
 }

--- a/src/lib/quaternion_test.mbt
+++ b/src/lib/quaternion_test.mbt
@@ -246,3 +246,22 @@ test "Quaternion::to_array/basic" {
   let q3 = @lib.from_array?([1.0, 2.0, 3.0, 4.0]).unwrap()
   inspect!(q3, content="Quaternion { w: 1, x: 2, y: 3, z: 4 }")
 }
+
+test "Quaternion::normalize/basic" {
+  let q = @lib.q(1.0, 2.0, 3.0, 4.0)
+  let result = q.normalize()
+  /// use roughly_eq
+  inspect!(
+    result.roughly_eq(@lib.Quaternion::{
+      w: 0.18257418203353882,
+      x: 0.3651483657360077,
+      y: 0.5477225184440613,
+      z: 0.7302967319488525,
+    }),
+    content="true",
+  )
+  inspect!(result.length(), content="1")
+  let q2 = @lib.q(1.0, 2.0, 3.0, 4.0)
+  q2.normalize_mut()
+  inspect!(q2.length(), content="1")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README with corrected spelling of "Mooncakes"
	- Added code snippets demonstrating Quaternion library usage

- **New Features**
	- Introduced `to_array` and `to_xyzw` methods for Quaternion
	- Added `from_wxyz` and `from_xyzw_array` methods with error handling for Quaternion
	- Added `from_euler_angles` method to create Quaternion from Euler angles
	- Added `roughly_eq` method for approximate equality check of Quaternions
	- Added normalization methods for Quaternions

- **Chores**
	- Bumped package version from 0.0.1 to 0.1.0

- **Tests**
	- Added new test cases for `to_array` method and related functionality in Quaternion
	- Added new test case for normalization of Quaternion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->